### PR TITLE
Add readers for "file ranges" like temporal_coherence

### DIFF
--- a/src/geepers/core.py
+++ b/src/geepers/core.py
@@ -217,7 +217,9 @@ def _get_quality_reader(
         )
     else:
         # Otherwise, the reader will be like other readers
-        return XarrayReader.from_file_list(quality_files, file_date_fmt)
+        return XarrayReader.from_file_list(
+            quality_files, file_date_fmt, units="unitless"
+        )
 
 
 def main(

--- a/src/geepers/gps.py
+++ b/src/geepers/gps.py
@@ -7,7 +7,9 @@ information, and handle GPS time series data.
 from __future__ import annotations
 
 import datetime
+import difflib
 import logging
+import re
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
@@ -178,9 +180,7 @@ def _get_station_plate(station_name: str) -> str:
     response = requests.get(url)
     response.raise_for_status()
 
-    import re
-
-    match = re.search(r"(?P<plate>[A-Z]{2}) Plate Fixed", response.text)
+    match = re.search(r"tenv3\/plates\/(?P<plate>[A-Z]{2})", response.text)
     if not match:
         msg = f"Could not find plate name on {url}"
         raise ValueError(msg)
@@ -407,8 +407,6 @@ def station_lonlat(station_name: str) -> tuple[float, float]:
     df = read_station_llas()
     station_name = station_name.upper()
     if station_name not in df["name"].values:
-        import difflib
-
         closest_names = difflib.get_close_matches(station_name, df["name"], n=5)
         msg = f"No station named {station_name} found. Closest: {closest_names}"
         raise ValueError(msg)

--- a/src/geepers/io.py
+++ b/src/geepers/io.py
@@ -221,9 +221,9 @@ class XarrayReader:
                 continue
 
             # lazily open once, drop the 'band' dim if present  ➜  2-D array
-            da = xr.open_dataset(fp, engine="rasterio").band_data.squeeze(
-                "band", drop=True
-            )
+            da = xr.open_dataset(
+                fp, engine="rasterio", chunks="auto"
+            ).band_data.squeeze("band", drop=True)
 
             # broadcast onto the matching epochs without data copy
             layers.append(da.expand_dims(time=target_times[mask]))


### PR DESCRIPTION
This adds the ability to quality rasters, like temporal coherence or phase similarity. You can provide per-ministack rasters (like the output of `dolphin`) or one for every displacement date.