### PR TITLE
Land toolbox documentation pages

### DIFF
--- a/docs/background-theory.md
+++ b/docs/background-theory.md
@@ -1,0 +1,240 @@
+# Background theory
+
+The methods implemented in geepers, with just enough math to interpret
+the outputs. References at the bottom.
+
+## Projecting GPS onto the radar line of sight
+
+InSAR measures the projection of the 3-D displacement onto the
+satellite line of sight. With the LOS unit vector
+$\mathbf{u} = (u_E, u_N, u_U)$ pointing from ground to satellite,
+
+$$
+d_\text{LOS} = u_E\, d_E + u_N\, d_N + u_U\, d_U .
+$$
+
+The GPS LOS uncertainty follows from the full ENU covariance
+$\Sigma$ (variances and correlations from the GPS solution):
+
+$$
+\sigma_\text{LOS}^2 = \mathbf{u}^\mathsf{T} \Sigma\, \mathbf{u},
+$$
+
+implemented in `geepers.uncertainty.get_sigma_los`. When the InSAR
+stack stores phase in radians, displacement is converted using the
+sensor wavelength passed to the workflow (Sentinel-1 C-band by
+default; pass `--wavelength 0.2384` for NISAR L-band).
+
+## MIDAS: robust velocities (`geepers.midas`)
+
+MIDAS (Blewitt et al., 2016) is a Theil-Sen-type estimator customized
+for GNSS. It forms data pairs separated by (almost exactly) one year —
+so seasonal cycles cancel by construction — optionally never spanning a
+known step epoch, and takes the median $\tilde v$ of the pair
+velocities. Outliers beyond $2\sigma$ (from the scaled MAD,
+$\sigma = 1.4826\,\mathrm{MAD}$) are removed and the median recomputed.
+The velocity uncertainty is
+
+$$
+\sigma_v = 3 \sqrt{\frac{\pi}{2}} \; \frac{\sigma}{\sqrt{N/4}},
+$$
+
+where $N$ is the number of retained pairs; the factor $\sqrt{\pi/2}$
+converts a median-based estimate to a standard-error equivalent, the
+$/4$ accounts for pair correlation, and the empirical factor 3 absorbs
+temporally correlated noise. MIDAS is insensitive to steps, outliers,
+and seasonality, but its uncertainty is a calibrated approximation
+rather than a noise-model-based estimate.
+
+## Trend estimation with colored noise (`geepers.trend`)
+
+GNSS residuals are not white: their power spectra behave as
+$P(f) \propto f^{\kappa}$ with spectral index $\kappa$ typically
+between $-1$ (flicker) and $0$ (white). Ignoring this makes
+least-squares velocity uncertainties 5-10× too small (Williams, 2003).
+
+geepers fits the deterministic model (polynomial, periodic terms,
+offsets, postseismic decays) *jointly* with a two-component noise model
+
+$$
+\mathbf{C}(\kappa, \phi) = \sigma^2 \left[ \phi\, \mathbf{I} +
+(1-\phi)\, \mathbf{C}_\text{PL}(\kappa) \right],
+$$
+
+where $\phi$ is the white-noise fraction. The power-law covariance uses
+the fractional-differencing formulation (Hosking, 1981): with
+$d = -\kappa/2$ and coefficients
+$\psi_0 = 1,\; \psi_i = \psi_{i-1}\,(d + i - 1)/i$,
+
+$$
+\mathbf{C}_\text{PL} = \mathbf{U}\mathbf{U}^\mathsf{T},
+\qquad U_{ij} = \psi_{i-j} \; (i \ge j),
+$$
+
+valid also for non-stationary noise ($\kappa \le -1$), evaluated at the
+observed epochs only, which handles data gaps exactly (Bos et al.,
+2013). For fixed $(\kappa, \phi)$ the model parameters come from
+generalized least squares and $\sigma^2$ is profiled out analytically;
+the two noise parameters are found by numerically maximizing the
+(restricted) log-likelihood
+
+$$
+-2\ln L = \ln\det\mathbf{C} + (n - p)\ln\hat\sigma^2 +
+\ln\det(\mathbf{A}^\mathsf{T}\mathbf{C}^{-1}\mathbf{A}) + \text{const},
+$$
+
+where the last term is the RMLE correction for the $p$ estimated model
+parameters. The velocity uncertainty is then read from
+$\hat\sigma^2 (\mathbf{A}^\mathsf{T}\mathbf{C}^{-1}\mathbf{A})^{-1}$ —
+it inherits the temporal correlation of the noise.
+
+The implementation is clean-room from the published equations and was
+validated against HectorP (Bos et al.): velocities agree to
+~0.005 mm/yr in well-conditioned cases; in the strongly
+flicker-dominated regime sub-1σ differences remain, traceable to
+HectorP's GGM regularization of the pure power law.
+
+### Fast spectral estimation (Whittle likelihood)
+
+For long series the O(n³) exact likelihood is replaced by the Whittle
+approximation: the periodogram of the (detrended) residuals is fit to
+the analytic power-law + white spectrum
+
+$$
+P(f) = \sigma_{pl}^2 \left| 2 \sin(\pi f \Delta t) \right|^{\kappa}
+ + \sigma_w^2,
+$$
+
+whose likelihood is a sum over frequencies — O(n log n). Noise
+parameters from the spectrum then feed one GLS solve for the trend and
+its uncertainty. Slightly coarser $\kappa$ estimates than the exact
+method, but usable on decades of daily data and whole networks
+(`estimate_trend_many`).
+
+## Common-mode error (`geepers.cme`)
+
+Stack the detrended residuals of a network into a matrix (epochs ×
+stations); its leading principal component(s) capture the coherent
+regional signal — reference-frame wobble and large-scale
+atmosphere/loading (Wdowinski et al., 1997 "stacking" generalized to
+PCA). Removing the reconstructed common mode
+$\mathbf{u}_k \mathbf{s}_k^\mathsf{T}$ typically shrinks per-station
+scatter by 30-50% without touching station-specific signals.
+
+## Step detection (`geepers.steps`)
+
+For each candidate epoch, two models are fit in a sliding window
+centered on it: a line, and a line plus a step. The epoch is flagged
+when the AIC improvement of the step model exceeds a threshold —
+a parameter-counted version of the classic two-sample test that is
+robust to the trend itself. Detections closer than a minimum separation
+are merged, keeping the strongest.
+
+## Strain rates (`geepers.strain`)
+
+From a gridded horizontal velocity field, the 2D infinitesimal
+strain-rate tensor is
+
+$$
+\dot\varepsilon_{xx} = \partial_x v_e,\quad
+\dot\varepsilon_{yy} = \partial_y v_n,\quad
+\dot\varepsilon_{xy} = \tfrac12(\partial_y v_e + \partial_x v_n),
+$$
+
+with gradients converted from per-degree to per-meter using spherical
+metric factors ($R\cos\varphi$ for longitude). Derived scalars:
+dilatation $\dot\varepsilon_{xx}+\dot\varepsilon_{yy}$, maximum shear
+$\sqrt{(\dot\varepsilon_{xx}-\dot\varepsilon_{yy})^2/4+\dot\varepsilon_{xy}^2}$,
+rotation $\tfrac12(\partial_x v_n - \partial_y v_e)$, and the second
+invariant.
+
+## Velocity variability metrics (`geepers.variability`)
+
+**Temporal**: MIDAS velocities are computed in half-overlapping sliding
+windows of every length from 3 years up to 75% of the record; the
+metric is the robust spread around the full-series velocity,
+$\sqrt{\mathrm{median}\left((v_\text{win} - v_\text{full})^2\right)}$,
+per component. Stations whose velocity depends on the observation
+window get large values — a warning sign for transients or unmodeled
+steps.
+
+**Spatial**: for each station, the RMS and MAD of the velocity
+differences with its Delaunay-network neighbors; gross outliers stand
+out immediately.
+
+**Spatial structure function (SSF)**: pairwise velocity differences
+binned by separation; the inverted, normalized curve (1 at zero
+distance, 0 at 180°) measures how coherence decays with distance
+(Hammond et al., 2016, eqs. 1-2).
+
+## GPS Imaging (`geepers.gps_imaging`)
+
+A robust interpolator built from three parts (Hammond et al., 2016):
+
+1. the **SSF** as above, with the zero-lag bin anchored at the median
+   measurement uncertainty and the per-bin scatter forced non-decreasing
+   with distance;
+2. **Delaunay neighborhoods** — each point is estimated from the
+   stations it is connected to in the triangulation (optionally
+   expanded to all stations within the median neighbor distance;
+   Kreemer et al., 2020);
+3. the **weighted median** of the neighborhood velocities, with weights
+   $w_i = \mathrm{SSF}(d_i)/\sigma_i$.
+
+Because the estimator is a median, single bad stations cannot leak into
+the map; and because there is no explicit smoothing, sharp velocity
+boundaries survive wherever stations constrain them. The geepers port
+reproduces the reference MATLAB kernels exactly (bit-identical SSF and
+weighted-median outputs on randomized tests).
+
+## Least-squares collocation (`geepers.collocation`)
+
+The geostatistical counterpart (Moritz, 1980). Observations are modeled
+as signal plus noise, $\mathbf{z} = \mathbf{s} + \mathbf{n}$, with
+signal covariance $\mathbf{C}_{ss}$ from a fitted isotropic model
+(first-order Gauss-Markov by default, $C(d) = C_0 e^{-d/d_0}$) and
+diagonal noise covariance $\mathbf{C}_{nn}$ from the station sigmas.
+The estimates at the stations and at new points $p$ are
+
+$$
+\hat{\mathbf{s}} = \mathbf{C}_{ss}(\mathbf{C}_{ss}+\mathbf{C}_{nn})^{-1}\mathbf{z},
+\qquad
+\hat{\mathbf{s}}_p = \mathbf{C}_{ps}(\mathbf{C}_{ss}+\mathbf{C}_{nn})^{-1}\mathbf{z},
+$$
+
+with error covariance
+$\mathbf{C}_{pp} - \mathbf{C}_{ps}(\mathbf{C}_{ss}+\mathbf{C}_{nn})^{-1}\mathbf{C}_{ps}^\mathsf{T}$
+— uncertainties grow away from data automatically. For horizontal
+velocity fields the east/north blocks are coupled by the angular
+covariance factors of a rotational field on the sphere, so the
+interpolation respects plate-rotation geometry. The model parameters
+$(C_0, d_0)$ come from the binned empirical covariogram of the data,
+with $C_0$ anchored at the noise-corrected variance
+$\overline{z^2} - \overline{\sigma^2}$.
+
+## References
+
+- Blewitt, G., Kreemer, C., Hammond, W. C., & Gazeaux, J. (2016). MIDAS
+  robust trend estimator for accurate GPS station velocities without
+  step detection. *J. Geophys. Res. Solid Earth*, 121, 2054-2068.
+  doi:10.1002/2015JB012552
+- Bos, M. S., Fernandes, R. M. S., Williams, S. D. P., & Bastos, L.
+  (2013). Fast error analysis of continuous GNSS observations with
+  missing data. *J. Geod.*, 87(4), 351-360.
+  doi:10.1007/s00190-012-0605-0
+- Hammond, W. C., Blewitt, G., & Kreemer, C. (2016). GPS Imaging of
+  vertical land motion in California and Nevada. *J. Geophys. Res.
+  Solid Earth*, 121, 7681-7703. doi:10.1002/2016JB013458
+- Hosking, J. R. M. (1981). Fractional differencing. *Biometrika*,
+  68(1), 165-176. doi:10.1093/biomet/68.1.165
+- Kreemer, C., Hammond, W. C., & Blewitt, G. (2020). A robust
+  estimation of the 3-D intraplate deformation of the North American
+  plate from GPS. *Geophys. Res. Lett.*, 47. doi:10.1029/2020GL087976
+- Moritz, H. (1980). *Advanced Physical Geodesy*. Wichmann, Karlsruhe.
+- Wdowinski, S., Bock, Y., Zhang, J., Fang, P., & Genrich, J.
+  (1997). Southern California permanent GPS geodetic array:
+  Spatial filtering of daily positions. *J. Geophys. Res.*, 102(B8),
+  18057-18070. doi:10.1029/97JB01378
+- Williams, S. D. P. (2003). The effect of coloured noise on the
+  uncertainties of rates estimated from geodetic time series.
+  *J. Geod.*, 76(9-10), 483-494. doi:10.1007/s00190-002-0283-4

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,8 +10,59 @@ mamba install -c conda-forge geepers
 
 ## Usage
 
-Example usage:
+### Compare an InSAR time series to GPS (main workflow)
 
+The `geepers` command samples an InSAR displacement stack at every GPS
+station inside its bounds, projects the GPS East/North/Up series onto the
+radar line of sight, and writes per-station comparison tables:
+
+```bash
+geepers \
+    --los path/to/los_enu.tif \
+    --timeseries-files displacement_*.tif \
+    --gps-source unr \
+    --wavelength 0.2384 \
+    -o ./GPS
+```
+
+- `--los` is a 3-band raster of the line-of-sight unit vector (ENU).
+- `--wavelength` (meters) is used only when the stack units are radians;
+  the default is Sentinel-1 C-band (~0.0555 m) — pass `0.2384` for
+  NISAR L-band.
+- Outputs: `combined_data.csv` (tidy GPS+InSAR series),
+  `relative_comparison.csv` (relative to a reference station,
+  auto-selected if not given via `--ref`), and `station_summary.csv`
+  (per-station rates and quality metrics).
+
+Run `geepers --help` for all options.
+
+### Download GPS data programmatically
+
+```python
+from geepers.gps_sources import UnrSource, UnrGridSource
+
+src = UnrSource()
+stations = src.stations(bbox=(-120, 35, -115, 40))     # (W, S, E, N)
+df = src.timeseries("P123", start_date="2015-01-01")   # one station
+gdf = src.timeseries_many(bbox=(-118, 36, -117, 37))   # all stations in box
+steps = src.steps(station_ids=["P123"])                # known offsets
+```
+
+`UnrGridSource` provides the UNR interpolated grid products the same way,
+and `SideshowSource` the JPL series.
+
+### Estimate velocities
+
+```python
+from geepers.trend import estimate_trend
+
+res = estimate_trend(df["date"], df["up"] * 1000, step_dates=steps["date"])
+print(f"{res.velocity:.2f} ± {res.velocity_uncertainty:.2f} mm/yr")
+```
+
+See [Analysis modules](analysis-modules.md) for the full velocity /
+interpolation / quality-metric toolbox, and the
+[tour notebook](notebooks/geepers_tour.ipynb) for a runnable demo.
 
 ## Setup for Developers
 
@@ -62,7 +113,7 @@ python -m pytest
 ### Creating Documentation
 
 We use [MKDocs](https://www.mkdocs.org/) to generate the documentation.
-The reference documentation is generated from the code docstrings using [mkdocstrings](mkdocstrings.github.io/).
+The reference documentation is generated from the code docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
 When adding new documentation, you can build and serve the documentation locally using:
 

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -1,0 +1,281 @@
+# How-To Guides
+
+Task-oriented recipes. Each assumes `geepers` is installed
+([Getting started](getting-started.md)) and, where GPS data is
+downloaded, network access to `geodesy.unr.edu` or
+`sideshow.jpl.nasa.gov`. Downloads are cached under
+`~/.cache/geepers/` (override with `cache_dir=` on any source).
+
+## How to validate an OPERA DISP product against GPS
+
+One command runs the full comparison — time series, velocities, and the
+structure-function requirement verification:
+
+```bash
+geepers \
+    --los los_enu.tif \
+    --timeseries-stack disp_product.zarr \
+    --stack-data-var displacement \
+    --wavelength 0.2384 \
+    --insar-buffer-meters 100 \
+    --requirement-mm 3 0.5 \
+    -o ./GPS_validation
+```
+
+Key choices:
+
+- `--insar-buffer-meters R` samples a **circular** footprint of radius
+  R meters around *every* GPS station (reference and secondary alike)
+  and takes the NaN-ignoring median — e.g. 100 m to suppress
+  single-pixel noise without mixing in different ground motion.
+  (`--insar-buffer N` is the older pixel-count rectangular variant.)
+- `--requirement-mm A B` draws and checks the requirement curve
+  ``A + B·√(distance_km)`` mm on the structure function (e.g. `3 0.5`).
+- `--gps-time-window D` applies a D-day rolling median to the GPS LOS
+  series (default 10; 0 disables).
+- If the product stores displacement in meters, `--wavelength` is
+  ignored; it only matters for stacks in radians (pass `0.2384` for
+  NISAR L-band).
+- `--ref STATION` fixes the reference station; otherwise the station
+  with the best temporal coherence / data coverage is auto-selected.
+
+Outputs in `GPS_validation/`:
+
+| file | contents |
+|---|---|
+| `combined_data.csv` | tidy per-station GPS + InSAR LOS series |
+| `relative_comparison.csv` | both series relative to the reference station |
+| `station_summary.csv` | per-station GPS (MIDAS) and InSAR rates + quality metrics |
+| `pairwise_rmse.csv` | structure function: relative RMSE + bias for every station pair vs separation |
+| `rmse_profile.csv` | binned median/mean/p90 RMSE per distance bin, `fraction_passing` if a requirement was given |
+| `epoch_rmse.csv` | network misfit per acquisition date — spikes flag bad epochs (ionosphere, unwrapping, snow) |
+| `structure_function.png` | pairs + binned curve + requirement line |
+
+The pairwise structure function differences the two stations' series
+*before* comparing, so any common reference or datum wobble cancels —
+it measures the product's relative accuracy the way the OPERA
+requirements are written. For programmatic access to the same metrics
+see [Analysis modules](analysis-modules.md#product-validation-geepersvalidation).
+
+## How to screen a GPS network before analysis
+
+```python
+import numpy as np
+from geepers.gps_sources import UnrSource
+from geepers.quality import gap_percentage
+from geepers.variability import temporal_velocity_variability
+
+src = UnrSource()
+stations = src.stations(bbox=(112, -39, 158, -10))  # W, S, E, N
+
+good = []
+for sid in stations["id"]:
+    df = src.timeseries(sid, start_date="2010-01-01")
+    # 1. Enough data, few gaps
+    span_yr = (df["date"].iloc[-1] - df["date"].iloc[0]).days / 365.25
+    if span_yr < 3 or gap_percentage(df["date"]) > 35:
+        continue
+    # 2. Velocity stable in time
+    tv = temporal_velocity_variability(df["date"], df[["east", "north", "up"]])
+    if tv.variability["up"] * 1000 > 2.0:  # mm/yr
+        continue
+    good.append(sid)
+```
+
+Add per-station spatial checks with
+`geepers.variability.spatial_variability` (neighbor RMS/MAD) and
+`ssf_per_station` once you have velocities for the whole network.
+
+Two more cleaning steps that pay off before velocity fitting:
+
+```python
+from geepers.steps import detect_steps_enu
+from geepers.cme import estimate_cme, remove_cme
+
+# 1. Find uncatalogued jumps; feed them to the trend/MIDAS estimators
+found = detect_steps_enu(df)                # complements UnrSource.steps()
+
+# 2. Estimate and remove the network common mode from detrended residuals
+cme = estimate_cme(residuals_by_station)    # epochs x stations DataFrame
+cleaned = cme.cleaned                       # or remove_cme(residuals_by_station)
+```
+
+## How to estimate a velocity with a realistic uncertainty
+
+```python
+from geepers.gps_sources import UnrSource
+from geepers.trend import estimate_trend
+
+src = UnrSource()
+df = src.timeseries("P123", start_date="2015-01-01")
+steps = src.steps(station_ids=["P123"])
+
+res = estimate_trend(
+    df["date"],
+    df["up"] * 1000,                      # meters -> mm
+    step_dates=steps["date"].tolist(),    # estimate offsets, don't span them
+    noise_model="PLWN",                   # power-law + white
+)
+print(f"v = {res.velocity:.2f} ± {res.velocity_uncertainty:.2f} mm/yr "
+      f"(kappa = {res.kappa:.2f})")
+```
+
+Use `noise_model="WN"` for a fast first pass (OLS-equivalent sigma,
+typically 5-10× too small), or `geepers.midas.midas` when robustness to
+unknown steps matters more than the noise model.
+
+## How to interpolate a velocity field onto a grid
+
+Robust, edge-preserving (GPS Imaging — cite Hammond et al., 2016):
+
+```python
+import numpy as np
+from geepers.gps_imaging import make_ssf, msf_interpolate
+
+ssf = make_ssf(lon, lat, v_up, sigma_up)
+gx, gy = np.meshgrid(np.arange(-120, -114, 0.1), np.arange(36, 41, 0.1))
+grid = msf_interpolate(lon, lat, v_up, sigma_up, gx.ravel(), gy.ravel(), ssf)
+v_grid = grid["value"].to_numpy().reshape(gx.shape)
+```
+
+Geostatistical, with covariance-propagated uncertainties (collocation):
+
+```python
+from geepers.collocation import empirical_covariance, interpolate_velocities
+
+emp = empirical_covariance(lon, lat, ve, vn, se, sn)
+at_stations, at_grid = interpolate_velocities(
+    lon, lat, ve, vn, se, sn, gx.ravel(), gy.ravel(),
+    covariance_parameters=emp.parameters,
+)
+```
+
+Rules of thumb: GPS Imaging for vertical land motion, outlier-prone
+networks, and sharp boundaries; collocation for smooth horizontal
+fields where you need rigorous sigmas. See
+[Analysis modules](analysis-modules.md#choosing-between-gps-imaging-and-collocation).
+
+## How to interpolate across plate boundaries (plate-separation constraint)
+
+A covariance model only knows *distance*: stations 50 km apart on
+opposite sides of a plate boundary look "close", and interpolation
+smears the velocity discontinuity across the boundary.
+`separate_plates` fixes this by building a working coordinate space in
+which each plate's points are pushed far apart (≥ 1500 km by default),
+so any distance-decaying covariance treats cross-plate pairs as
+uncorrelated — while within-plate geometry is preserved.
+
+The recipe: **assign & separate → interpolate in moved coordinates →
+attach results back to the true coordinates.**
+
+Self-contained synthetic example (two plates with discontinuous motion):
+
+```python
+import geopandas as gpd
+import numpy as np
+from shapely.geometry import box
+
+from geepers.collocation import (
+    ordinary_kriging, separate_plates,
+)
+
+rng = np.random.default_rng(1)
+
+# Two plates meeting at lon = 5°, moving differently
+plates = gpd.GeoDataFrame(
+    {"code": ["A", "B"]},
+    geometry=[box(0, 0, 5, 10), box(5, 0, 10, 10)],
+    crs="EPSG:4326",
+)
+n = 80
+lon = np.r_[rng.uniform(0.5, 4.5, n // 2), rng.uniform(5.5, 9.5, n // 2)]
+lat = rng.uniform(1, 9, n)
+v = np.where(lon < 5, -2.0, 3.0) + rng.normal(0, 0.3, n)   # 5 mm/yr jump
+sv = np.full(n, 0.3)
+
+# Evaluation grid spanning the boundary
+gx, gy = np.meshgrid(np.linspace(0.5, 9.5, 60), np.linspace(1, 9, 40))
+
+# --- 1. Separate stations AND grid points together (one call, so both
+#        get consistent working coordinates)
+all_lon = np.r_[lon, gx.ravel()]
+all_lat = np.r_[lat, gy.ravel()]
+lon_m, lat_m, plate_idx = separate_plates(
+    all_lon, all_lat, plates, min_separation_km=1500
+)
+slon_m, slat_m = lon_m[:n], lat_m[:n]          # stations, moved
+glon_m, glat_m = lon_m[n:], lat_m[n:]          # grid, moved
+
+# --- 2. Interpolate in the moved space
+params = np.array([1.0, 200.0])                 # (C0, d0) — or fit with
+                                                # empirical_covariance on
+                                                # the *moved* coordinates
+unconstrained = ordinary_kriging(lon, lat, v, sv, gx.ravel(), gy.ravel(), params)
+constrained   = ordinary_kriging(slon_m, slat_m, v, sv, glon_m, glat_m, params)
+
+# --- 3. Results map back trivially: constrained.signal[i] belongs to
+#        the true coordinate (gx.ravel()[i], gy.ravel()[i])
+v_unc = unconstrained.signal.reshape(gx.shape)  # boundary smeared
+v_con = constrained.signal.reshape(gx.shape)    # sharp step at lon=5°
+```
+
+Plotting `v_unc` vs `v_con` shows the difference: without the
+constraint the −2 → +3 mm/yr step is blurred over ~2 x d0; with it,
+each grid node is informed only by stations on its own plate.
+
+The same moved coordinates work for `interpolate_velocities` (LSC) and
+`geepers.gps_imaging.msf_interpolate` — pass `slon_m/slat_m` and
+`glon_m/glat_m` wherever station/evaluation coordinates go, and always
+fit `empirical_covariance` / `make_ssf` on the **moved** coordinates so
+cross-plate pairs don't contaminate the covariogram.
+
+Real-data notes:
+
+- Plate polygons: use e.g. the Bird (2003) plate-boundary model, or
+  your project's plate shapefile —
+  `plates = gpd.read_file("plates.shp")`. Points falling outside every
+  polygon are assigned to the nearest plate (the original workflow
+  silently dropped them).
+- **Horizontal velocities**: remove each plate's rigid rotation
+  *before* interpolating and restore it afterward — otherwise the plate
+  motion itself dominates the field. Use `geepers.euler`:
+
+  ```python
+  from geepers.euler import estimate_euler_pole, predict_plate_motion
+
+  for k in np.unique(plate_idx[:n]):        # per plate
+      sel = plate_idx[:n] == k
+      pole = estimate_euler_pole(lon[sel], lat[sel], ve[sel], vn[sel],
+                                 se[sel], sn[sel])
+      vp_e, vp_n = predict_plate_motion(pole, lon[sel], lat[sel])
+      ve[sel] -= vp_e; vn[sel] -= vp_n      # remove (restore after)
+  ```
+
+  (or build the `EulerPole` from published ITRF2014-PMM values).
+  Vertical velocities need no such correction, which makes them the
+  simplest case.
+- Choose `min_separation_km` several times larger than the fitted
+  correlation length `d0` (the 1500 km default suits d0 ≲ 300 km).
+
+## How to browse UNR grid time series interactively
+
+```bash
+cd scripts/
+python create-geoparquet.py --bbox -110 28 -101 36 --start-date 2016-01-01
+python -m http.server 8123
+# open http://localhost:8123/browse_unr_grid.html
+```
+
+The viewer loads the Parquet directly in the browser (no server-side
+processing) with a date slider, per-point time-series charts, and WebM
+animation export. See `scripts/README.md` for details.
+
+## How to point the download cache somewhere else
+
+Every data source accepts `cache_dir`:
+
+```python
+src = UnrSource(cache_dir="/big/disk/gps_cache")
+```
+
+or set `XDG_CACHE_HOME` to relocate all caches.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,9 @@
 
 1. [Getting started](./getting-started.md)
 1. [Tutorials](tutorials.md)
+1. [Analysis modules](analysis-modules.md) — MIDAS, trend + noise
+   modeling, variability metrics, GPS Imaging, collocation
+   ([runnable tour notebook](notebooks/geepers_tour.ipynb))
 1. [How-To Guides](how-to-guides.md)
 1. [Code Reference](reference/summary.md)
 1. [Background theory](background-theory.md)

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,17 +1,70 @@
-This part of the project documentation will contain step-by-step instructions for learning how to use the project.
+# Tutorials
 
-<!-- **learning-oriented** approach. You'll learn how to
-get started with the code in this project.
+## GNSS vs InSAR validation (notebook)
 
-**Note:** Expand this section by considering the
-following points:
+The [GNSS-InSAR validation notebook](notebooks/gnss_insar_validation.ipynb)
+runs the complete comparison workflow on the real Sentinel-1 Kīlauea test
+dataset that ships with the repository: metric-buffer sampling,
+per-station time series, velocity scatter, the structure function with a
+requirement curve, per-epoch network misfit, and the effect of the
+sampling buffer radius. It is the executable companion to
+[How to validate an OPERA DISP product against GPS](how-to-guides.md#how-to-validate-an-opera-disp-product-against-gps).
 
-- Help newcomers with getting started
-- Teach readers about your library by making them
-    write code
-- Inspire confidence through examples that work for
-    everyone, repeatably
-- Give readers an immediate sense of achievement
-- Show concrete examples, no abstractions
-- Provide the minimum necessary explanation
-- Avoid any distractions -->
+## Tour of the analysis modules (notebook)
+
+The [geepers tour notebook](notebooks/geepers_tour.ipynb) is a runnable,
+self-contained walkthrough — synthetic data with known truth, so every
+result can be checked against what went in:
+
+1. robust velocities with **MIDAS**;
+2. velocities with **realistic uncertainties** under power-law + white
+   noise, and why OLS sigmas are 5-10× too optimistic;
+3. **temporal velocity variability** (sliding-window MIDAS);
+4. spotting bad stations with **spatial variability**;
+5. interpolating a velocity field two ways — robust **GPS Imaging**
+   vs. geostatistical **collocation** — on a field with a sharp
+   boundary and a corrupted station.
+
+Run it locally with:
+
+```bash
+jupyter lab docs/notebooks/geepers_tour.ipynb
+```
+
+## Your first GPS-InSAR comparison
+
+1. **Gather inputs**: a stack of displacement rasters (one per date,
+   dates in the filenames) or a Zarr/NetCDF cube, plus a 3-band
+   line-of-sight ENU raster on the same grid.
+
+2. **Run the workflow**:
+
+   ```bash
+   geepers --los los_enu.tif --timeseries-files displacement_*.tif -o GPS
+   ```
+
+   GPS stations inside the raster bounds are discovered and downloaded
+   automatically (cached under `~/.cache/geepers`).
+
+3. **Look at the outputs** in `GPS/`:
+
+   - `combined_data.csv` — every GPS and InSAR LOS series, tidy format;
+   - `relative_comparison.csv` — both series referenced to a common
+     station;
+   - `station_summary.csv` — per-station GPS (MIDAS) and InSAR rates,
+     their difference, and quality metrics.
+
+4. **Plot a station** (pandas one-liner):
+
+   ```python
+   import pandas as pd
+   df = pd.read_csv("GPS/combined_data.csv", parse_dates=["date"])
+   (df[df.id == "P123"]
+      .pivot_table(index="date", columns="measurement", values="value")
+      [["los_gps", "los_insar"]]
+      .plot(style=".", ms=3))
+   ```
+
+For recipes on screening stations, estimating velocities, and gridding
+velocity fields, see the [How-To Guides](how-to-guides.md); for the
+underlying methods, see [Background theory](background-theory.md).


### PR DESCRIPTION
## Summary
Brings the analysis-toolbox documentation that was authored on `unr-grid-viewer-updates` alongside the code but not included in #46. All five pages already exist in the mkdocs `nav`, so this is a content update (no nav change).

| Page | What it adds |
|---|---|
| `how-to-guides.md` | validate vs GPS, network screening, velocity uncertainty, interpolation, plate-boundary-constrained interpolation |
| `background-theory.md` | theory for the trend / collocation / euler methods |
| `tutorials.md` | toolbox tutorials |
| `getting-started.md` | toolbox coverage + a malformed-link fix |
| `index.md` | minor polish |

## Why
`analysis-modules.md` (merged in #46) links into `how-to-guides.md` anchors that didn't exist on main — **dead links**. This restores them and completes the docs set that the API reference + notebooks were built around.

## Validation
- `mkdocs build` (geepers-env, `PYTHONPATH=src`) is **clean** — no unresolved links or anchors.
- pre-commit (end-of-file, whitespace, line-ending) passes.

After merge, the GitHub Pages docs will be redeployed so the live `/docs/` reflects the complete set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)