### PR TITLE
Add regression tests for core modules

### DIFF
--- a/tests/gps_sources/test_unr_grid.py
+++ b/tests/gps_sources/test_unr_grid.py
@@ -1,6 +1,11 @@
 """Tests for UNR Grid GPS data source."""
 
+from __future__ import annotations
+
+import numpy as np
+
 from geepers.gps_sources.unr_grid import UnrGridSource
+from geepers.schemas import EPS
 
 
 class TestUnrGridSource:
@@ -10,3 +15,63 @@ class TestUnrGridSource:
         """Test UnrGridSource initialization."""
         source = UnrGridSource()
         assert isinstance(source, UnrGridSource)
+
+
+class TestParseDataFile:
+    """Regression tests for the .tenv8 parser.
+
+    Locks the contract that later refactors must preserve: unit conversion
+    (UNR grid files are in millimeters), placeholder correlations, datetime
+    derivation, and the zero-sigma clamp that keeps the schema happy for the
+    time-constant gridded products.
+    """
+
+    # decimal_year east north up sig_e sig_n sig_u rapid_flag  (mm)
+    TENV8 = (
+        "2020.0000  12.0  -8.0   3.0   1.0  1.5  2.0  0\n"
+        "2020.5000  15.0  -6.0   5.0   1.2  1.4  2.1  0\n"
+        "2021.0000  18.0  -4.0   7.0   0.0  0.0  0.0  1\n"
+    )
+
+    def _write(self, tmp_path):
+        p = tmp_path / "000007_NA.tenv8"
+        p.write_text(self.TENV8)
+        return p
+
+    def test_columns_and_units(self, tmp_path):
+        df = UnrGridSource().parse_data_file(self._write(tmp_path))
+        assert list(df.columns) == [
+            "date",
+            "east",
+            "north",
+            "up",
+            "sigma_east",
+            "sigma_north",
+            "sigma_up",
+            "corr_en",
+            "corr_eu",
+            "corr_nu",
+        ]
+        # millimeters -> meters for values and sigmas
+        np.testing.assert_allclose(df["east"].to_numpy(), [0.012, 0.015, 0.018])
+        np.testing.assert_allclose(df["north"].to_numpy(), [-0.008, -0.006, -0.004])
+        np.testing.assert_allclose(df["up"].to_numpy(), [0.003, 0.005, 0.007])
+        np.testing.assert_allclose(df["sigma_north"].to_numpy(), [0.0015, 0.0014, EPS])
+
+    def test_zero_sigma_clamped_to_eps(self, tmp_path):
+        # The last row has exactly-zero sigmas (time-constant products);
+        # they must be clamped to the schema minimum, not left at 0.
+        df = UnrGridSource().parse_data_file(self._write(tmp_path))
+        last = df.iloc[-1]
+        assert last["sigma_east"] == EPS
+        assert last["sigma_north"] == EPS
+        assert last["sigma_up"] == EPS
+
+    def test_placeholder_correlations_are_zero(self, tmp_path):
+        df = UnrGridSource().parse_data_file(self._write(tmp_path))
+        assert (df[["corr_en", "corr_eu", "corr_nu"]] == 0.0).all().all()
+
+    def test_dates_from_decimal_year(self, tmp_path):
+        df = UnrGridSource().parse_data_file(self._write(tmp_path))
+        got = [d.date().isoformat() for d in df["date"]]
+        assert got == ["2020-01-01", "2020-07-02", "2020-12-31"]

--- a/tests/test_collocation.py
+++ b/tests/test_collocation.py
@@ -307,3 +307,57 @@ class TestSeparatePlates:
         # rigid-ish translation: pairwise distances change by < 5%
         scale = d_after[d_before > 10] / d_before[d_before > 10]
         assert 0.95 < np.median(scale) < 1.05
+
+
+class TestInterpolateVelocitiesRegression:
+    """Golden-value regression for the collocation interpolation entry point.
+
+    With covariance parameters supplied explicitly the whole path is
+    deterministic linear algebra (no empirical estimation / optimization), so
+    the interpolated signal and its uncertainty are pinned exactly. Guards
+    against silent changes to the covariance assembly or the collocation solve.
+    """
+
+    # Fixed 8-station network (deg) with a smooth horizontal velocity field.
+    LON = np.array([-118.0, -117.6, -117.2, -118.0, -117.2, -117.6, -117.8, -117.4])
+    LAT = np.array([34.0, 34.0, 34.0, 34.6, 34.6, 34.6, 34.3, 34.3])
+    EAST = np.array([2.0, 2.4, 2.8, 2.3, 3.1, 2.7, 2.45, 2.65])
+    NORTH = np.array([-1.0, -0.88, -0.76, -1.12, -0.88, -1.0, -1.0, -0.94])
+    PARAMS = np.array([[4.0, 40.0]])  # (C0 mm^2, d0 km)
+
+    def _run(self):
+        se = np.full(self.LON.size, 0.2)
+        sn = np.full(self.LON.size, 0.2)
+        lon_n = np.array([-117.6, -117.8])
+        lat_n = np.array([34.3, 34.15])
+        return interpolate_velocities(
+            self.LON,
+            self.LAT,
+            self.EAST,
+            self.NORTH,
+            se,
+            sn,
+            lon_n,
+            lat_n,
+            covariance_parameters=self.PARAMS,
+        )
+
+    def test_interpolated_signal_and_sigma(self):
+        _, at_new = self._run()
+        np.testing.assert_allclose(
+            np.asarray(at_new.signal),
+            [[2.55293065, -0.96402871], [2.26822667, -0.94776713]],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        np.testing.assert_allclose(
+            np.asarray(at_new.signal_sigma),
+            [[1.28685762, 1.28685906], [1.29859423, 1.29859321]],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    def test_deterministic(self):
+        _, a = self._run()
+        _, b = self._run()
+        np.testing.assert_array_equal(np.asarray(a.signal), np.asarray(b.signal))

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -277,3 +277,38 @@ class TestEstimateTrendMany:
         assert list(df.index) == ["good", "bad"]
         assert np.isfinite(df.loc["good", "velocity"])
         assert np.isnan(df.loc["bad", "velocity"])
+
+
+class TestEstimateTrendRegression:
+    """Golden-value regression: on a noise-free line + annual signal the
+    design-matrix solve must recover the inputs to machine precision. This
+    pins the model parameterization (trend + sin_1yr/cos_1yr) and the
+    least-squares path, independent of the noise estimator.
+    """
+
+    def _signal(self):
+        dates = pd.to_datetime("2016-01-01") + pd.to_timedelta(
+            np.arange(0, 4 * 365, 1), unit="D"
+        )
+        t = (dates - dates[0]).days.to_numpy() / 365.25
+        # intercept 1.0, velocity 5.0, annual = 2.0*sin + 0.5*cos
+        y = 1.0 + 5.0 * t + 2.0 * np.sin(2 * np.pi * t) + 0.5 * np.cos(2 * np.pi * t)
+        return dates, y
+
+    def test_recovers_exact_parameters(self):
+        dates, y = self._signal()
+        res = estimate_trend(dates, y, noise_model="WN", periods_years=(1.0,))
+        assert res.velocity == pytest.approx(5.0, abs=1e-6)
+        assert res.parameters["intercept"][0] == pytest.approx(1.0, abs=1e-6)
+        assert res.parameters["sin_1yr"][0] == pytest.approx(2.0, abs=1e-6)
+        assert res.parameters["cos_1yr"][0] == pytest.approx(0.5, abs=1e-6)
+        # noise-free -> the formal trend uncertainty collapses to ~0
+        assert res.velocity_uncertainty < 1e-6
+        # fitted model reproduces the data
+        np.testing.assert_allclose(res.model, y, atol=1e-6)
+
+    def test_annual_amplitude(self):
+        dates, y = self._signal()
+        res = estimate_trend(dates, y, noise_model="WN", periods_years=(1.0,))
+        amp = np.hypot(res.parameters["sin_1yr"][0], res.parameters["cos_1yr"][0])
+        assert amp == pytest.approx(np.hypot(2.0, 0.5), abs=1e-6)


### PR DESCRIPTION
## Summary
Regression tests locking the behavior of the core modules against silent regressions. The grid-source tests were previously just `test_init` smoke tests; the estimators had property/recovery tests but no behavior-pinning ones.

| Module | Regression coverage added |
|---|---|
| **`UnrGridSource.parse_data_file`** | fixture-based `.tenv8` parse (no network): mm→m unit conversion, placeholder correlations, decimal-year→datetime, and the zero-sigma→EPS clamp for time-constant products |
| **`estimate_trend`** | noise-free line + annual signal recovers exact trend / intercept / annual parameters to machine precision — pins the model parameterization + least-squares path |
| **`interpolate_velocities`** (collocation) | with explicit covariance parameters the path is deterministic linear algebra; pins the interpolated signal + uncertainty (golden values) and run-to-run determinism |

## Why these are robust
- Grid parse and trend recovery are exact/deterministic (no RNG, no optimizer), so they won't drift across numpy/scipy versions.
- Collocation golden values use **explicit** covariance parameters, bypassing the empirical estimation/optimization, so the result is a pure matrix solve — reproducible (asserted with `rtol=1e-5`).

## Validation
- New tests: **8 added**, all pass in the CI-matched pixi test env.
- Full suite: **217 passed, 5 skipped**.
- black + ruff (pinned) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)